### PR TITLE
src/Composer/Composer.php: fix autoloading when analyzing scip-php

### DIFF
--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -113,7 +113,11 @@ final class Composer
             $vendorDir = trim($json['config']['vendor-dir'], '/');
         }
         $this->vendorDir = self::join($projectRoot, $vendorDir);
-        $this->loader = require self::join($this->vendorDir, 'autoload.php');
+
+        $projectAutoload = Reader::read(self::join($this->vendorDir, 'autoload.php'));
+        $scipPhpAutoload = Reader::read(self::join($this->scipPhpVendorDir, 'autoload.php'));
+        $autoloadDir = $projectAutoload === $scipPhpAutoload ? $this->scipPhpVendorDir : $this->vendorDir;
+        $this->loader = require self::join($autoloadDir, 'autoload.php');
 
         $installed = require self::join($this->vendorDir, 'composer', 'installed.php');
         $this->pkgName = $installed['root']['name'];


### PR DESCRIPTION
Since composer 2.6.4 [0], the autoloader suffix reuses the content-hash from the lock file in order to make the builds more reproducible [1]. This lead to a conflict when analyzing scip-php itself when using the Docker container.

[0] https://github.com/composer/composer/releases/tag/2.6.4
[1] https://github.com/composer/composer/pull/11663
