### PR TITLE
use composer.json version field if reference is null

### DIFF
--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -121,7 +121,7 @@ final class Composer
 
         $installed = require self::join($this->vendorDir, 'composer', 'installed.php');
         $this->pkgName = $installed['root']['name'];
-        $this->pkgVersion = $installed['root']['reference'];
+        $this->pkgVersion = $installed['root']['reference'] ?? $installed['root']['version'];
 
         $additionalClasses = [];
         foreach ($this->projectFiles as $f) {


### PR DESCRIPTION
## Related issues

- [536](https://github.com/davidrjenni/scip-php/issues/536)  


## Proposed changes

<!-- Please include the 'why' behind your changes if no issue exists. -->

- if you define a `version` in your root composer.json, the index `reference` will be `null` in the `root` array of your vendor/composer/installed.php
- however the index `version` will be available in that array
- use `version` (i.e. `"1.0.0"`) if `reference` is `null`
