### PR TITLE
Fix Windows path handling and runtime isolation

### DIFF
--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -82,6 +82,16 @@ final class Composer
         return implode(DIRECTORY_SEPARATOR, [$elem, ...$elems]);
     }
 
+    /** @return non-empty-string */
+    private static function trimPathSeparators(string $path): string
+    {
+        $trimmed = rtrim($path, '/\\');
+        if ($trimmed === '') {
+            return $path;
+        }
+        return $trimmed;
+    }
+
     /** @param  non-empty-string  $projectRoot */
     public function __construct(private readonly string $projectRoot)
     {
@@ -123,7 +133,7 @@ final class Composer
             is_array($json['config'] ?? null)
             && is_string($json['config']['vendor-dir'] ?? null)
         ) {
-            $dir = trim($json['config']['vendor-dir'], '/');
+            $dir = trim($json['config']['vendor-dir'], '/\\');
             if ($dir !== '') {
                 $vendorDir = $dir;
             }
@@ -136,6 +146,9 @@ final class Composer
         $loader = require self::join($autoloadDir, 'autoload.php');
         if (!$loader instanceof ClassLoader) {
             throw new RuntimeException("Cannot get autoload.php class loader.");
+        }
+        if ($autoloadDir !== $this->scipPhpVendorDir) {
+            $loader->unregister();
         }
         $this->loader = $loader;
 
@@ -279,7 +292,7 @@ final class Composer
                         continue;
                     }
                     $p = self::join($this->projectRoot, $path);
-                    $p = rtrim($p, DIRECTORY_SEPARATOR);
+                    $p = self::trimPathSeparators($p);
                     $generator->scanPaths($p, $exclusionRegex, $t, $ns);
                 }
             }

--- a/src/Composer/Composer.php
+++ b/src/Composer/Composer.php
@@ -92,6 +92,27 @@ final class Composer
         return $trimmed;
     }
 
+    /** @return ?non-empty-string */
+    private static function discoverScipPhpVendorDir(): ?string
+    {
+        $packageRoot = self::join(__DIR__, '..', '..');
+        $candidates = [
+            self::join($packageRoot, 'vendor'),
+            self::join($packageRoot, '..', '..'),
+        ];
+        foreach ($candidates as $candidate) {
+            $autoload = self::join($candidate, 'autoload.php');
+            if (!is_file($autoload)) {
+                continue;
+            }
+            $realPath = realpath($candidate);
+            if ($realPath !== false) {
+                return $realPath;
+            }
+        }
+        return null;
+    }
+
     /** @param  non-empty-string  $projectRoot */
     public function __construct(private readonly string $projectRoot)
     {
@@ -99,8 +120,8 @@ final class Composer
         $autoload = is_array($json['autoload'] ?? null) ? $json['autoload'] : [];
         $autoloadDev = is_array($json['autoload-dev'] ?? null) ? $json['autoload-dev'] : [];
 
-        $scipPhpVendorDir = self::join(__DIR__, '..', '..', 'vendor');
-        if (realpath($scipPhpVendorDir) === false) {
+        $scipPhpVendorDir = self::discoverScipPhpVendorDir();
+        if ($scipPhpVendorDir === null) {
             // If the vendor directory relative to this file is not found, scip-php probably runs as a
             // dev dependency of the project that it analyses and shares the vendor directory with it.
             $cwd = getcwd();

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -17,6 +17,8 @@ use ScipPhp\Types\Types;
 
 use function array_values;
 use function str_replace;
+use function str_starts_with;
+use function substr;
 
 final readonly class Indexer
 {
@@ -57,6 +59,18 @@ final readonly class Indexer
         $this->types = new Types($this->composer, $this->namer);
     }
 
+    /** @return non-empty-string */
+    private function relativePath(string $filename): string
+    {
+        $normalizedProjectRoot = str_replace('\\', '/', $this->projectRoot);
+        $normalizedFilename = str_replace('\\', '/', $filename);
+        $prefix = $normalizedProjectRoot . '/';
+        if (str_starts_with($normalizedFilename, $prefix)) {
+            return substr($normalizedFilename, \strlen($prefix));
+        }
+        return $normalizedFilename;
+    }
+
     public function index(): Index
     {
         $projectFiles = $this->composer->projectFiles();
@@ -69,7 +83,7 @@ final readonly class Indexer
             $this->parser->traverse($filename, $indexer, $indexer->index(...));
             $documents[] = new Document([
                 'language'          => Language::PHP,
-                'relative_path'     => str_replace($this->projectRoot . '/', '', $filename),
+                'relative_path'     => $this->relativePath($filename),
                 'occurrences'       => $indexer->occurrences,
                 'symbols'           => array_values($indexer->symbols),
                 'position_encoding' => PositionEncoding::UTF8CodeUnitOffsetFromLineStart,

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -93,6 +93,16 @@ final class ComposerTest extends TestCase
         self::assertSame('foo\\bar', $method->invoke(null, 'foo\\bar/'));
     }
 
+    public function testDiscoverScipPhpVendorDirFindsOwnVendorDirectory(): void
+    {
+        $method = new ReflectionMethod(Composer::class, 'discoverScipPhpVendorDir');
+        $vendorDir = $method->invoke(null);
+
+        self::assertIsString($vendorDir);
+        self::assertStringEndsWith(self::join('vendor'), $vendorDir);
+        self::assertFileExists(self::join($vendorDir, 'autoload.php'));
+    }
+
     public function testIsDependency(): void
     {
         foreach ([...self::BUILTIN, ...self::DEPS, ...self::UNKNOWN] as $idents) {

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Composer;
 
 use Override;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ScipPhp\Composer\Composer;
 
 use function count;
@@ -80,6 +81,16 @@ final class ComposerTest extends TestCase
         self::assertStringEndsWith(self::join($root, 'src', 'file2.php'), $files[2]);
         self::assertStringEndsWith(self::join($root, 'src', 'ClassA.php'), $files[3]);
         self::assertStringEndsWith(self::join($root, 'tests', 'ClassATestCase.php'), $files[4]);
+    }
+
+    public function testTrimPathSeparatorsSupportsBothSlashStyles(): void
+    {
+        $method = new ReflectionMethod(Composer::class, 'trimPathSeparators');
+
+        self::assertSame('foo/bar', $method->invoke(null, 'foo/bar/'));
+        self::assertSame('foo\\bar', $method->invoke(null, 'foo\\bar\\'));
+        self::assertSame('foo/bar', $method->invoke(null, 'foo/bar\\'));
+        self::assertSame('foo\\bar', $method->invoke(null, 'foo\\bar/'));
     }
 
     public function testIsDependency(): void

--- a/tests/Indexer/IndexerTest.php
+++ b/tests/Indexer/IndexerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Indexer;
 use Override;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ScipPhp\File\Reader;
@@ -89,6 +90,17 @@ final class IndexerTest extends TestCase
 
             self::assertSame($golden, $actual);
         }
+    }
+
+    public function testRelativePathNormalizesWindowsSeparators(): void
+    {
+        $indexer = new Indexer(self::TESTDATA_DIR . 'scip-php-test', 'test', []);
+        $method = new ReflectionMethod(Indexer::class, 'relativePath');
+
+        self::assertSame(
+            'src/Foo.php',
+            $method->invoke($indexer, self::TESTDATA_DIR . 'scip-php-test\\src\\Foo.php'),
+        );
     }
 
     /** @return array<non-empty-string, non-empty-string> */


### PR DESCRIPTION
﻿## Summary

Fix four Windows/runtime issues discovered while validating `scip-php` on a real Laravel project:

- trim Composer autoload paths with both `/` and `\\`
- discover the indexer's own `vendor/` correctly when `scip-php` is installed as a dependency under `vendor/davidrjenni/scip-php`
- unregister the target project's autoloader when `scip-php` runs outside the target `vendor/`
- normalize emitted `relative_path` values so Windows artifacts stay project-relative

Closes #814.

## Validation

- `vendor/bin/phpunit --no-coverage tests/Composer/ComposerTest.php`
- `vendor/bin/phpunit --no-coverage tests/Indexer/IndexerTest.php`
- live repro on a real Laravel project on Windows now produces a non-empty `.scip` artifact with project-relative document paths
- downstream validation in `hex-graph-mcp` successfully imported the generated PHP SCIP artifact back into the native graph and materialized `scip_import` edges
